### PR TITLE
Dynamically set ZEEBE_CONTACT_POINTS

### DIFF
--- a/02_configmap_zeebe.yml
+++ b/02_configmap_zeebe.yml
@@ -10,17 +10,17 @@ data:
     configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
     export ZEEBE_HOST=$(hostname -f)
     export ZEEBE_NODE_ID="${HOSTNAME##*-}"
+    
     # We need to specify all brokers as contact points for partition healing to work correctly
     # https://github.com/zeebe-io/zeebe/issues/2684
-    export ZEEBE_CONTACT_POINTS=zeebe-0.$(hostname -d):26502,zeebe-1.$(hostname -d):26502,zeebe-2.$(hostname -d):26502
-    #if [ "${HOSTNAME##*-}" -ne "0" ]; then
-    #  export ZEEBE_CONTACT_POINTS="zeebe-0.zeebe":26502
-    #fi
+    ZEEBE_CONTACT_POINTS=${HOSTBASE}0.$(hostname -d):26502
+    for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
+    do
+        ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"
+    done
+    export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
+    
     exec /usr/local/zeebe/bin/broker
-    # Cleanup data
-    #rm -rf /usr/local/zeebe/data/*
-    #echo "Done cleaning up"
-    #sleep 3600
   zeebe.cfg.toml: |
     # Zeebe broker configuration file
 

--- a/02_configmap_zeebe.yml
+++ b/02_configmap_zeebe.yml
@@ -13,7 +13,7 @@ data:
     
     # We need to specify all brokers as contact points for partition healing to work correctly
     # https://github.com/zeebe-io/zeebe/issues/2684
-    ZEEBE_CONTACT_POINTS=${HOSTBASE}0.$(hostname -d):26502
+    ZEEBE_CONTACT_POINTS=${HOSTNAME::-1}0.$(hostname -d):26502
     for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
     do
         ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"


### PR DESCRIPTION
As a Kubernetes StatefulSet is used, we can predict all the contact points that will be created within the StatefulSet based on $ZEEBE_CLUSTER_SIZE (which should be defined in a cluster and should be equal to the StatefulSets number of replicas).