### PR TITLE
fixing typo on install-gcp script

### DIFF
--- a/install-gke.sh
+++ b/install-gke.sh
@@ -7,7 +7,7 @@ $KUBECTL 02_configmap_zeebe.yml
 $KUBECTL 03_storageclass_zeebe-gcp.yml
 $KUBECTL 04_service_zeebe.yml
 $KUBECTL 10_statefulset_zeebe.yml
-$KUBECTL 20_storageclass_elasticsearch-gcp.yaml
+$KUBECTL 20_storageclass_elasticsearch-gcp.yml
 $KUBECTL 21_persistentvolumeclaim_elasticsearch.yml
 $KUBECTL 22_service_elasticsearch.yml
 $KUBECTL 25_deployment_elasticsearch.yml


### PR DESCRIPTION
This PR just fixes a small typo in the install-gke.sh file which uses the yaml extension instead of yml