### PR TITLE
Setting port 80 for HTTP services that will be exposed

### DIFF
--- a/31_service_kibana.yml
+++ b/31_service_kibana.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterIP: None # <--
   ports:
-  - port: 5601
+  - port: 80
     name: http
     targetPort: 5601
     protocol: TCP

--- a/41_service_operate.yml
+++ b/41_service_operate.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterIP: None # <--
   ports:
-  - port: 8080
+  - port: 80
     name: http
     targetPort: 8080
     protocol: TCP


### PR DESCRIPTION
We can use http port 80 to make easy to call services just by their names.
In this case we should be able to do:
 - http://operate
 - http://kibana

without the need for the port, due it is implicit. 
This will be used by the ingress definitions in a following PR
